### PR TITLE
Update to Kotlin 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ certain versions of Kotlin.
 
 | Kotlin          | Exhaustive |
 |-----------------|------------|
-| 1.4.10 - 1.4.20 | 0.1.1      |
+| 1.4.10 - 1.5.0  | 0.1.1      |
 
 Versions of Kotlin older than 1.4.10 are not supported.
 Versions newer than those listed may be supported but are untested.

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.versions = [
-      'kotlin': '1.4.20',
-      'autoService': '1.0-rc7',
+      'kotlin': '1.5.0',
+      'autoService': '1.0',
   ]
 
   ext.deps = [
@@ -15,14 +15,14 @@ buildscript {
           'compiler': "com.google.auto.service:auto-service:${versions.autoService}",
       ],
       'kotlinCompileTesting': 'com.github.tschuchortdev:kotlin-compile-testing:1.3.1',
-      'junit': 'junit:junit:4.13.1',
-      'truth': 'com.google.truth:truth:1.1',
+      'junit': 'junit:junit:4.13.2',
+      'truth': 'com.google.truth:truth:1.1.2',
   ]
 
   dependencies {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
     classpath 'com.diffplug.spotless:spotless-plugin-gradle:5.1.0'
-    classpath 'com.vanniktech:gradle-maven-publish-plugin:0.13.0'
+    classpath 'com.vanniktech:gradle-maven-publish-plugin:0.14.2'
     classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.10.0'
   }
 

--- a/exhaustive-gradle/src/test/fixture/android-instrumentation-test/build.gradle
+++ b/exhaustive-gradle/src/test/fixture/android-instrumentation-test/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10'
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     classpath 'com.android.tools.build:gradle:4.1.0'
     classpath "app.cash.exhaustive:exhaustive-gradle:${exhaustiveVersion}"
   }

--- a/exhaustive-gradle/src/test/fixture/android-unit-test/build.gradle
+++ b/exhaustive-gradle/src/test/fixture/android-unit-test/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10'
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     classpath 'com.android.tools.build:gradle:4.1.0'
     classpath "app.cash.exhaustive:exhaustive-gradle:${exhaustiveVersion}"
   }

--- a/exhaustive-gradle/src/test/fixture/android/build.gradle
+++ b/exhaustive-gradle/src/test/fixture/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10'
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     classpath 'com.android.tools.build:gradle:4.1.0'
     classpath "app.cash.exhaustive:exhaustive-gradle:${exhaustiveVersion}"
   }

--- a/exhaustive-gradle/src/test/fixture/js-test/build.gradle
+++ b/exhaustive-gradle/src/test/fixture/js-test/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10'
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     classpath "app.cash.exhaustive:exhaustive-gradle:${exhaustiveVersion}"
   }
   repositories {

--- a/exhaustive-gradle/src/test/fixture/js/build.gradle
+++ b/exhaustive-gradle/src/test/fixture/js/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10'
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     classpath "app.cash.exhaustive:exhaustive-gradle:${exhaustiveVersion}"
   }
   repositories {

--- a/exhaustive-gradle/src/test/fixture/jvm-test/build.gradle
+++ b/exhaustive-gradle/src/test/fixture/jvm-test/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10'
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     classpath "app.cash.exhaustive:exhaustive-gradle:${exhaustiveVersion}"
   }
   repositories {

--- a/exhaustive-gradle/src/test/fixture/jvm/build.gradle
+++ b/exhaustive-gradle/src/test/fixture/jvm/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10'
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     classpath "app.cash.exhaustive:exhaustive-gradle:${exhaustiveVersion}"
   }
   repositories {

--- a/exhaustive-gradle/src/test/fixture/mpp-test/build.gradle
+++ b/exhaustive-gradle/src/test/fixture/mpp-test/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10'
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     classpath "app.cash.exhaustive:exhaustive-gradle:${exhaustiveVersion}"
   }
   repositories {

--- a/exhaustive-gradle/src/test/fixture/mpp/build.gradle
+++ b/exhaustive-gradle/src/test/fixture/mpp/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10'
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0'
     classpath "app.cash.exhaustive:exhaustive-gradle:${exhaustiveVersion}"
   }
   repositories {


### PR DESCRIPTION
The released version appears to work just fine with 1.5.0 so this will not come with a release.

Closes #12.